### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/theories/Util/Strings/String.v
+++ b/theories/Util/Strings/String.v
@@ -1,6 +1,6 @@
-Require Import Coq.micromega.Lia.
-Require Import Coq.Strings.String.
-Require Import Coq.Strings.Ascii.
+From Coq Require Import Lia.
+From Coq Require Import String.
+From Coq Require Import Ascii.
 Require Import NeuralNetInterp.Util.Strings.Ascii.
 
 Local Open Scope list_scope.


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
