### PR TITLE
Fix Python CI: fetch the public wandb artifacts without a credential

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,5 +64,7 @@ jobs:
         action: remove
         linters: flake8
     - run: make check
-    - run: wandb login --anonymously
+    # No `wandb login` here: `--anonymously` is no longer honoured server side
+    # (it 401s), and the models these scripts need are public artifacts, which
+    # training_utils.py now fetches without credentials.
     - run: make analyze

--- a/training/training_utils.py
+++ b/training/training_utils.py
@@ -5,7 +5,10 @@
 # In[ ]:
 
 import datetime
+import json
 import os, os.path
+import shutil
+import urllib.request
 from pathlib import Path
 from typing import List, Any, Iterable, Optional
 import numpy as np
@@ -23,6 +26,21 @@ def default_device(deterministic: bool = False) -> str:
 # In[ ]:
 
 DEFAULT_WANDB_ENTITY = 'team-jason' # 'tkwa-team' # 'team-jason'
+
+WANDB_PUBLIC_GRAPHQL_URL = 'https://api.wandb.ai/graphql'
+
+_WANDB_PUBLIC_ARTIFACT_FILES_QUERY = '''
+query ArtifactFiles($entityName: String!, $projectName: String!, $artifactName: String!) {
+  project(name: $projectName, entityName: $entityName) {
+    artifact(name: $artifactName) {
+      state
+      files(first: 100) {
+        edges { node { name sizeBytes directUrl } }
+      }
+    }
+  }
+}
+'''
 
 # In[ ]:
 
@@ -162,6 +180,53 @@ def make_wandb_config(
       'device':device,
     }
 
+def _wandb_public_graphql(query: str, variables: dict, timeout: float = 60) -> dict:
+  """POST an unauthenticated query to the public wandb GraphQL API."""
+  payload = json.dumps({'query': query, 'variables': variables}).encode('utf-8')
+  request = urllib.request.Request(
+      WANDB_PUBLIC_GRAPHQL_URL,
+      data=payload,
+      headers={'Content-Type': 'application/json', 'User-Agent': 'neural-net-coq-interp'})
+  with urllib.request.urlopen(request, timeout=timeout) as response:
+    result = json.loads(response.read().decode('utf-8'))
+  if result.get('errors'):
+    raise RuntimeError(f'wandb GraphQL errors: {result["errors"]}')
+  return result['data']
+
+def download_public_wandb_artifact(wandb_artifact_path: str, dest_dir, timeout: float = 60) -> Optional[Path]:
+  """Download the files of a *public* wandb artifact without authenticating.
+
+  `wandb.Api()` insists on an API key even for public data, and `wandb login
+  --anonymously` no longer works server side, so unauthenticated CI cannot use
+  the normal client at all. Public artifacts are still readable through the
+  public GraphQL API, which hands back pre-signed storage URLs we can fetch
+  directly.
+
+  `wandb_artifact_path` is the usual `entity/project/name:alias` string.
+  Returns the directory the files were written to, or None if the artifact has
+  no files.
+  """
+  entity_name, project_name, artifact_name = wandb_artifact_path.split('/')
+  data = _wandb_public_graphql(
+      _WANDB_PUBLIC_ARTIFACT_FILES_QUERY,
+      {'entityName': entity_name, 'projectName': project_name, 'artifactName': artifact_name},
+      timeout=timeout)
+  artifact = (data.get('project') or {}).get('artifact')
+  if artifact is None:
+    raise RuntimeError(f'No such public wandb artifact: {wandb_artifact_path}')
+  edges = artifact['files']['edges']
+  if not edges: return None
+  dest_dir = Path(dest_dir)
+  os.makedirs(dest_dir, exist_ok=True)
+  for edge in edges:
+    node = edge['node']
+    if node.get('directUrl') is None: continue
+    dest_path = dest_dir / os.path.basename(node['name'])
+    with urllib.request.urlopen(node['directUrl'], timeout=timeout) as response, open(dest_path, 'wb') as dest_file:
+      shutil.copyfileobj(response, dest_file)
+    print(f'Downloaded {wandb_artifact_path} file {node["name"]} ({node["sizeBytes"]} bytes) to {dest_path}')
+  return dest_dir
+
 def load_model(model: HookedTransformer, model_pth_path: str):
   try:
     cached_data = torch.load(model_pth_path)
@@ -226,6 +291,13 @@ def train_or_load_model(
         model_dir = Path(model_at.download())
       except Exception as e:
         print(f'Could not load model {wandb_model_path} from wandb:\n', e)
+        # The wandb client needs an API key even to read a public artifact, so
+        # this is the expected path anywhere there is no key (CI, fresh
+        # checkouts); fall back to fetching the public artifact directly.
+        try:
+          model_dir = download_public_wandb_artifact(wandb_model_path, pth_base_path / 'wandb-public' / wandb_project)
+        except Exception as e:
+          print(f'Could not download public artifact {wandb_model_path} from wandb:\n', e)
       if model_dir is not None:
         for model_path in model_dir.glob('*.pth'):
           res = load_model(model, model_path)


### PR DESCRIPTION
Python CI has been red since some time between 2025-11-21 (last green run) and 2026-07-28. This fixes it.

## What is actually failing

Exactly one step, on every run:

```
Run wandb login --anonymously
Error: The API key you provided is either invalid or missing.
  (Error 401: Unauthorized)
```

`make analyze` is then reported as `skipped`, and the job is red. Steps 1-10 (checkout, setup-python, apt deps, pip install, flake8) all conclude `success`. Confirmed identical on runs 30332272500 (2026-07-28) and 31323084384 (2026-08-09).

Nothing in this repo caused it. The workflow file at the last green run already contained these same two steps (`wandb login --anonymously`, then `make analyze`), so the change is server side at W&B.

## flake8 is a red herring — please do not chase it

A reader opening a failing run sees roughly 1900 flake8 findings and a wall of red `##[error]` annotations. **None of them fail the build.** The lint step runs flake8 twice:

- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` — this is the blocking one. It prints `0`.
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics` — `--exit-zero` by construction.

The annotations come from the second invocation, surfaced by `liskin/gh-problem-matcher-wrap`. The lint step's own conclusion is `success`. This PR does not touch the ~1900 style findings.

## Why `--anonymously` cannot be made to work, and why upgrading wandb does not help

Anonymous login is a removed server-side feature. Measured locally, in a clean `HOME` with `WANDB_API_KEY` unset:

- `wandb==0.15.10` (the pinned version): reproduces CI's 401 exactly, rc=1.
- `wandb==0.28.1` (current): `wandb: WARNING The --anonymously parameter has no effect and will be removed in a future version.` followed by `Error: No API key configured. Use 'wandb login' to log in.`, rc=1.

So bumping the pin does not fix this step, and this PR leaves `requirements.txt` alone.

## The scripts *fetch from* W&B, they do not merely *log to* it — so offline mode cannot help

This distinction decides the fix, so it is worth being explicit.

`make analyze` runs each script with `--fail-if-cant-load`, which reaches `train_or_load_model(..., fail_if_cant_load=True)`. There is no `.pth` checked into the repo, and `get_pth_base_path()` points at a freshly created `$(cwd)/trained-models`, so the only path that can produce a model is:

```python
api = wandb.Api()
model_at = api.artifact(wandb_model_path)
model_dir = Path(model_at.download())
```

`WANDB_MODE=offline` therefore cannot help, and I measured that rather than assuming it: on the unmodified tree, in a clean `HOME` with `WANDB_MODE=offline` set, `make analyze` still exits 2 with

```
AssertionError: Couldn't load model from .../trained-models/...pth or wandb
(team-jason/neural-net-coq-interp-max-2-epochs-1500/neural-net-coq-interp-max-2-epochs-1500:latest),
and fail_if_cant_load is True
```

## The fix

Both models are **public** artifacts, and public artifacts are readable from W&B's GraphQL API with **no credential at all** — it is only the `wandb` *client* that insists on a key before it will do anything. Verified with plain `urllib`, no key, no netrc, clean `HOME`:

| artifact | result |
| --- | --- |
| `team-jason/neural-net-coq-interp-max-2-epochs-1500/...:latest` | `COMMITTED`, 110,651 B, 1 file, `directUrl` on `storage.googleapis.com` |
| `team-jason/neural-net-coq-interp-max-5-epochs-9950/...:latest` | `COMMITTED`, 515,291 B, 1 file, likewise |

(The project itself reports `access: "USER_READ"` to an unauthenticated caller.)

So, two changes:

1. **`training/training_utils.py`** — when `wandb.Api()` cannot start, fall back to querying the public GraphQL API for the artifact's files and fetching their pre-signed URLs directly, into `trained-models/wandb-public/<project>/`. The existing `model_dir.glob('*.pth')` loop then proceeds unchanged. `wandb.Api()` remains the *primary* path, so anyone with a key in `~/.netrc` keeps the normal client behaviour and this code never runs for them. Standard library only — no new dependency.

2. **`.github/workflows/python.yml`** — drop the dead `wandb login --anonymously` step.

Deliberately **not** done: no `secrets.WANDB_API_KEY` gate. It is not needed, and avoiding it means `make analyze` stays real on fork PRs and on the dependabot PRs against `/training`, which never receive secrets.

## What was verified locally, and what was not

In a scratchpad venv on Python 3.11 from `training/requirements.txt`, run with a clean `HOME` and `WANDB_API_KEY` unset so there is no credential in play:

- `make check` — rc=0, all 5 files, 0 tracebacks.
- `make analyze` — **rc=0**, 31.9 s wall, 574 MB peak RSS. All three scripts fell through to the new path (`Could not load model ... api_key not configured` immediately followed by `Downloaded ... (110651 bytes)` / `(515291 bytes)`), loaded the models, and `proof_max2_01_exhaustive.py` reports `accuracy is 1.0`.
- Negative control, same clean `HOME`, unmodified tree via `git archive HEAD`: `make analyze` → rc=2, the AssertionError quoted above. And with `WANDB_MODE=offline`: also rc=2, same error.
- CI's blocking flake8 invocation over `training/`: 0 findings, rc=0 — with a positive control (a deliberate syntax error in a throwaway file) confirming that gate is actually live and returns rc=1.

Two honest caveats:

- **`gmpy2==2.1.2` was omitted from the local venv** (107 of the 108 pinned requirements installed). It needs `mpc.h` to build from source and I had no way to install system headers on that box; CI installs `libgmp-dev libmpfr-dev libmpc-dev` and builds it fine. `gmpy2` is imported by no Python file in this repo — it appears only in `requirements.txt` and `environment.yml`, so it cannot affect the result. Untouched here regardless.
- `make analyze-only-big` was **not** run, locally or in CI; it is not part of this workflow.
