### PR TITLE
Rocq CI: add 9.1/9.2/9.3 and a wide master row, drop 8.17-8.19, skip on Python-only changes

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -7,9 +7,14 @@ on:
       - _CoqProject
       - Makefile
       - Makefile.coq.local
+      - etc/**
       - .github/workflows/coq.yml
     branches:
       - main
+  # No `paths:` filter here on purpose: `check-all` is a required status check,
+  # and a workflow that never starts never reports it, so the PR would sit on
+  # "Expected - waiting for status to be reported" forever.  The skip is done
+  # per-job below, via the `changes` job.
   pull_request:
   workflow_dispatch:
 
@@ -17,24 +22,156 @@ permissions:
   contents: write
 
 jobs:
+  changes:
+    name: Detect Rocq-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      coq: ${{ steps.filter.outputs.coq }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - id: filter
+      name: Did anything Rocq-relevant change?
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      run: |
+        set -u
+        # Keep this in sync with the `paths:` filter on `push:` above.
+        RELEVANT='^(theories/|etc/|_CoqProject$|Makefile$|Makefile\.coq\.local$|\.github/workflows/coq\.yml$)'
+        build_everything() {
+          echo "$1; building everything"
+          echo "coq=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        }
+        case "$EVENT_NAME" in
+          push|pull_request) ;;
+          *) build_everything "event is $EVENT_NAME, not push or pull_request" ;;
+        esac
+        case "$BASE_SHA" in
+          ''|0000000000000000000000000000000000000000)
+            build_everything "no usable base sha" ;;
+        esac
+        git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null \
+          || git fetch --no-tags origin "$BASE_SHA" 2>/dev/null \
+          || true
+        git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null \
+          || build_everything "base $BASE_SHA is not resolvable"
+        CHANGED="$(git diff --name-only "$BASE_SHA" HEAD)" \
+          || build_everything "git diff against $BASE_SHA failed"
+        echo "Changed files since $BASE_SHA:"
+        printf '%s\n' "$CHANGED"
+        if printf '%s\n' "$CHANGED" | grep -qE "$RELEVANT"; then
+          echo "coq=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No Rocq-relevant path changed; skipping the build jobs."
+          echo "coq=false" >> "$GITHUB_OUTPUT"
+        fi
+
   docker-build:
+    needs: changes
+    if: needs.changes.outputs.coq == 'true'
     strategy:
       fail-fast: false
       matrix:
         include:
-        - env: { COQ_VERSION: "master", DOCKER_COQ_VERSION: "dev" , DOCKER_MATHCOMP_VERSION: "2.4.0" , DOCKER_COQ_NAME: "rocq-prover", DOCKER_OCAML_VERSION: "default", OPAM_DEPS: "coq-record-update coq-flocq", LAPROOF: "", TGTS: "computed", INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" }
-        - env: { COQ_VERSION: "9.0"   , DOCKER_COQ_VERSION: "9.0" , DOCKER_MATHCOMP_VERSION: "2.4.0" , DOCKER_COQ_NAME: "rocq-prover", DOCKER_OCAML_VERSION: "default", OPAM_DEPS: "coq-record-update coq-flocq coq-interval coq-mathcomp-zify coq-mathcomp-analysis coq-mathcomp-algebra-tactics coq-mathcomp-finmap"                                , LAPROOF: "" , TGTS: "", INSTALL_TGTS: "install", OPAM_UPDATE_CMD: "" }
-        - env: { COQ_VERSION: "8.20"  , DOCKER_COQ_VERSION: "8.20", DOCKER_MATHCOMP_VERSION: "2.3.0" , DOCKER_COQ_NAME: "coq"        , DOCKER_OCAML_VERSION: "default", OPAM_DEPS: "coq-record-update coq-flocq coq-interval coq-vcfloat coq-mathcomp-zify coq-mathcomp-analysis coq-mathcomp-algebra-tactics coq-mathcomp-finmap coq-vst coq-vst-lib", LAPROOF: "" , TGTS: "", INSTALL_TGTS: "install", OPAM_UPDATE_CMD: "" }
-        - env: { COQ_VERSION: "8.19"  , DOCKER_COQ_VERSION: "8.19", DOCKER_MATHCOMP_VERSION: "1.19.0", DOCKER_COQ_NAME: "coq"        , DOCKER_OCAML_VERSION: "default", OPAM_DEPS: "coq-record-update coq-flocq coq-interval coq-vcfloat coq-mathcomp-zify coq-mathcomp-analysis coq-mathcomp-algebra-tactics coq-mathcomp-finmap coq-vst coq-vst-lib", LAPROOF: "" , TGTS: "", INSTALL_TGTS: "install", OPAM_UPDATE_CMD: "" }
-        # - env: { COQ_VERSION: "8.18"  , DOCKER_COQ_VERSION: "8.18", DOCKER_MATHCOMP_VERSION: "1.18.0", DOCKER_COQ_NAME: "coq"        , DOCKER_OCAML_VERSION: "default", OPAM_DEPS: "coq-record-update coq-flocq", LAPROOF: "", TGTS: "computed", INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" } # broken with   File "./theories/TransformerLens/HookedTransformer.v", line 128, characters 4-421: Error: Error: Missing notation term for variables i1 i_ j1 j_ k1   k_, probably an ill-typed expression
-        - env: { COQ_VERSION: "8.17"  , DOCKER_COQ_VERSION: "8.17", DOCKER_MATHCOMP_VERSION: "1.17.0", DOCKER_COQ_NAME: "coq"        , DOCKER_OCAML_VERSION: "default", OPAM_DEPS: "coq-record-update coq-flocq coq-interval coq-vcfloat coq-mathcomp-zify coq-mathcomp-analysis coq-mathcomp-algebra-tactics coq-mathcomp-finmap coq-vst coq-vst-lib", LAPROOF: "1", TGTS: "", INSTALL_TGTS: "install", OPAM_UPDATE_CMD: "" }
+        # The `master` rows deliberately use `rocq/rocq-prover:dev` rather than
+        # `mathcomp/mathcomp:2.4.0-rocq-prover-dev`, which is what this row used
+        # to use.  That mathcomp tag has gone stale: `rocq --version` inside it
+        # reports "The Rocq Prover, version 9.2+alpha", i.e. it is *older* than
+        # the released 9.2, so the row named "master" was not testing master.
+        # `rocq/rocq-prover:dev` reports 9.3+alpha.  Nothing in the target set
+        # below needs mathcomp, so dropping the mathcomp image costs nothing.
+        #
+        # `computed` is the fast canary: ~20 min, green on every run since at
+        # least 2025-11.  Keep it separate from the big job below so that a new
+        # break in the wider set is distinguishable from a break in the core.
+        - env: { COQ_VERSION: "master"                       , DOCKER_IMAGE: ""                                       , DOCKER_COQ_VERSION: "dev", DOCKER_OCAML_VERSION: "default", EXPECT_VERSION: "9."  , OPAM_DEPS: "coq-record-update coq-flocq"                                                                                    , LAPROOF: "", TGTS: "computed"     , INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" }
+        # 152 of the 160 files in _CoqProject, against 102 for `computed`; see
+        # CI_SKIP/CI_SKIP_NO_INTERVAL in Makefile.coq.local for the measured
+        # reason behind each of the 8 that are left out.
+        - env: { COQ_VERSION: "master (everything buildable)", DOCKER_IMAGE: ""                                       , DOCKER_COQ_VERSION: "dev", DOCKER_OCAML_VERSION: "default", EXPECT_VERSION: "9."  , OPAM_DEPS: "coq-record-update coq-flocq"                                                                                    , LAPROOF: "", TGTS: "ci-all-no-interval", INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" }
+        # No mathcomp image is published for 9.3, so this row gets
+        # rocq/rocq-prover:9.3 from coq_version, and therefore builds the same
+        # mathcomp-free target set as the master rows.
+        - env: { COQ_VERSION: "9.3"                          , DOCKER_IMAGE: ""                                       , DOCKER_COQ_VERSION: "9.3", DOCKER_OCAML_VERSION: "default", EXPECT_VERSION: "9.3" , OPAM_DEPS: "coq-record-update coq-flocq"                                                                                    , LAPROOF: "", TGTS: "ci-all-no-interval", INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" }
+        # `OPAM_UPDATE_CMD` is load-bearing on this row and only on this row.
+        # The 9.2 image ships a frozen opam-repository snapshot in which the
+        # newest `coq-flocq` is 4.2.2 with a `coq < 8.21~` bound and there is no
+        # `rocq-flocq` at all, so `opam install coq-record-update coq-flocq`
+        # *succeeds* (exit 0) by removing rocq-core/rocq-runtime/rocq-stdlib and
+        # the whole mathcomp 2.6.0 stack and installing coq 8.16.1 in their
+        # place.  Refreshing the repository makes coq-flocq 4.2.2 resolve
+        # against coq-core 9.2.0 instead, with no removals.  See also the
+        # prover-version assertion after `opam install` below.
+        - env: { COQ_VERSION: "9.2"                          , DOCKER_IMAGE: "mathcomp/mathcomp:2.6.0-rocq-prover-9.2", DOCKER_COQ_VERSION: "9.2", DOCKER_OCAML_VERSION: "default", EXPECT_VERSION: "9.2" , OPAM_DEPS: "coq-record-update coq-flocq"                                                                                    , LAPROOF: "", TGTS: "ci-all-no-interval", INSTALL_TGTS: "", OPAM_UPDATE_CMD: "opam update -y" }
+        - env: { COQ_VERSION: "9.1"                          , DOCKER_IMAGE: "mathcomp/mathcomp:2.4.0-rocq-prover-9.1", DOCKER_COQ_VERSION: "9.1", DOCKER_OCAML_VERSION: "default", EXPECT_VERSION: "9.1" , OPAM_DEPS: "coq-record-update coq-flocq coq-interval coq-coquelicot coq-mathcomp-analysis coq-mathcomp-reals-stdlib", LAPROOF: "", TGTS: "ci-all"       , INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" }
+        - env: { COQ_VERSION: "9.0"                          , DOCKER_IMAGE: "mathcomp/mathcomp:2.4.0-rocq-prover-9.0", DOCKER_COQ_VERSION: "9.0", DOCKER_OCAML_VERSION: "default", EXPECT_VERSION: "9.0" , OPAM_DEPS: "coq-record-update coq-flocq coq-interval coq-coquelicot coq-mathcomp-analysis coq-mathcomp-reals-stdlib", LAPROOF: "", TGTS: "ci-all"       , INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" }
+        # 8.20 keeps its row, but on the plain `coqorg/coq` image and with only
+        # the two dependencies the target set actually needs.  It used to
+        # install the interval/vcfloat/VST stack and died *in that install*,
+        # never reaching a single `.v` file: `coq-vst.3.1beta` pulls
+        # `coq-compcert` and then rejects it ("COMPCERT VERSION MISMATCH:
+        # COMPCERT_VERSION=version=3.15 but .../compcert/VERSION=version=3.17").
+        # Nothing in `ci-all-no-interval` uses VST, so the fix is to stop
+        # installing it rather than to pin around it; with the minimal pair the
+        # row installs clean and builds the same 152 files as 9.3.
+        - env: { COQ_VERSION: "8.20"                         , DOCKER_IMAGE: ""                                       , DOCKER_COQ_VERSION: "8.20", DOCKER_OCAML_VERSION: "default", EXPECT_VERSION: "8.20", OPAM_DEPS: "coq-record-update coq-flocq"                                                                                   , LAPROOF: "", TGTS: "ci-all-no-interval", INSTALL_TGTS: "", OPAM_UPDATE_CMD: "" }
+        # Dropped rows.  All three have failed on every recorded run since
+        # 2025-11-05, and all three were re-measured on the plain coqorg/coq
+        # image with the minimal dependency pair -- i.e. the configuration that
+        # rescued 8.20 -- so these are source-side limits, not dependency-solver
+        # accidents.
+        #
+        # None of it is rot.  Three deliberate forward-ports did it, each right
+        # for the prover it was adapting to: 5b496f9 "Adapt to rocq#21211"
+        # (2025-11-05) dropped `at level 2` from 15 Slicing.v notations and
+        # added the `PrimArray` import; 6f2c7db "Adapt to rocq#21849"
+        # (2026-04-03) rewrote `%type` to `%_type` at 32 sites in 4 files; and
+        # c1f7905/58058f2 (2026-07/08) dropped the `@@1`/`@@2` levels for Rocq
+        # 9.4.  This PR takes back only the `PrimArray` import, which costs
+        # nothing anywhere.
+        #
+        # 8.19: `theories/Torch/Slicing.v`, line 222: "Error: A left-recursive
+        #   notation must have an explicit level."  106 of 160 files built.
+        #   Putting back the levels 5b496f9 removed does fix 8.19 -- measured,
+        #   152 of 160, rc 0 --
+        #   but it is NOT backwards compatible, because the level that has to
+        #   be stated changed under us.  `_ .[ _ , .. , _ ]` has to sit at the
+        #   same level as the stdlib `_ .[ _ ]` it shares a prefix with, and
+        #   that notation is at level 2 in Coq 8.19/8.20 and Rocq 9.0/9.1 but
+        #   at level 1 in Rocq 9.2 and later (read off the
+        #   notation-incompatible-prefix warnings of each build).  8.20+ infer
+        #   the right one; a literal cannot be right on both sides.  Writing
+        #   `at level 2` turned 9.2/9.3/master red at
+        #   `TransformerLens/HookedTransformer.v:115`, "Syntax error: '<-' or
+        #   ']' expected after [term level 200]".  Reverted, and 8.19 dropped.
+        # - env: { COQ_VERSION: "8.19", DOCKER_COQ_VERSION: "8.19", TGTS: "ci-all-no-interval", ... }
+        #
+        # 8.18: `theories/TransformerLens/HookedTransformer.v`, line 128,
+        #   characters 4-421: "Error: Missing notation term for variables i1 i_
+        #   j1 j_ k1 k_, probably an ill-typed expression".  83 of 160 files
+        #   built.  It also hits the same `%_type` problem 8.17 does.
+        # - env: { COQ_VERSION: "8.18", DOCKER_COQ_VERSION: "8.18", TGTS: "ci-all-no-interval", ... }
+        #
+        # 8.17: `theories/Util/PolymorphicSigma.v:24` uses the `%_type` scope
+        #   delimiter, which does not exist before 8.19 (there it is `%type`).
+        #   No form parses on both sides of 8.19, so keeping 8.17 means
+        #   reverting 6f2c7db at all 32 sites, or carrying a second spelling for
+        #   a prover four majors behind.  This is the row that was green until
+        #   2025-11-05 (last green run 19051159010 at `06a316c`, first red run
+        #   19110435928, which is 5b496f9 itself): it is dropped because keeping
+        #   it means undoing two upstream adaptations, not because it never
+        #   worked.
+        # - env: { COQ_VERSION: "8.17", DOCKER_COQ_VERSION: "8.17", TGTS: "ci-all-no-interval", ... }
 
     runs-on: ubuntu-latest
     env: ${{ matrix.env }}
     name: ${{ matrix.env.COQ_VERSION }}
 
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.env.COQ_VERSION }}-docker-build-${{ github.head_ref || github.run_id }}
+      group: ${{ github.workflow }}-${{ matrix.env.COQ_VERSION }}-${{ matrix.env.TGTS }}-docker-build-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
     steps:
@@ -46,9 +183,12 @@ jobs:
     - name: make ${{ matrix.env.TGTS }}
       uses: coq-community/docker-coq-action@v1
       with:
-        custom_image: mathcomp/mathcomp:${{ matrix.env.DOCKER_MATHCOMP_VERSION }}-${{ matrix.env.DOCKER_COQ_NAME }}-${{ matrix.env.DOCKER_COQ_VERSION }}
-        #coq_version: ${{ matrix.env.DOCKER_COQ_VERSION }}
-        #ocaml_version: ${{ matrix.env.DOCKER_OCAML_VERSION }}
+        # An empty `custom_image` falls through to deriving the image from
+        # coq_version/ocaml_version, which is how the 9.3 row gets
+        # rocq/rocq-prover:9.3 (no mathcomp image is published for 9.3).
+        custom_image: ${{ matrix.env.DOCKER_IMAGE }}
+        coq_version: ${{ matrix.env.DOCKER_COQ_VERSION }}
+        ocaml_version: ${{ matrix.env.DOCKER_OCAML_VERSION }}
         export: CI
         custom_script: |
           eval $(opam env)
@@ -58,6 +198,20 @@ jobs:
           startGroup 'install dependencies'
           ${{ matrix.env.OPAM_UPDATE_CMD }}
           opam install -y -v ${{ matrix.env.OPAM_DEPS }}
+          endGroup
+          startGroup 'check that the prover survived dependency installation'
+          # A dependency capped at `coq < 8.21~` does not make `opam install`
+          # fail: opam satisfies it by *uninstalling* the Rocq prover and
+          # installing Coq 8.x in its place, and exits 0.  The row then reports
+          # source errors against a prover several majors older than the one it
+          # is named after -- which is exactly what the 9.2 row did until
+          # OPAM_UPDATE_CMD was added above.  Assert the version instead.
+          PROVER_VERSION="$( { rocq --version || rocqc --version || coqc --version ; } 2>&1 | head -n 1 )"
+          echo "prover after dependency installation: $PROVER_VERSION"
+          case "$PROVER_VERSION" in
+            *"version ${{ matrix.env.EXPECT_VERSION }}"*) ;;
+            *) echo "::error::expected a ${{ matrix.env.EXPECT_VERSION }} prover, got: $PROVER_VERSION"; exit 1 ;;
+          esac
           endGroup
           startGroup 'install LAProof'
           if [ ! -z "${{ matrix.env.LAPROOF }}" ]; then
@@ -80,6 +234,8 @@ jobs:
           make print-pretty-timed
 
   docker-build-native:
+    needs: changes
+    if: needs.changes.outputs.coq == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -138,17 +294,18 @@ jobs:
 
   check-all:
     runs-on: ubuntu-latest
-    needs: [docker-build, docker-build-native]
+    needs: [changes, docker-build, docker-build-native]
     if: always()
     steps:
-    - run: echo 'docker-build passed'
-      if: ${{ needs.docker-build.result == 'success' }}
-    - run: echo 'docker-build-native passed'
-      if: ${{ needs.docker-build-native.result == 'success' }}
+    - run: echo 'changes=${{ needs.changes.result }} docker-build=${{ needs.docker-build.result }} docker-build-native=${{ needs.docker-build-native.result }}'
+    # `skipped` has to count as passing: this is a required status check, and
+    # the build jobs are deliberately skipped on Python-only changes.
+    - run: echo 'changes failed' && false
+      if: ${{ needs.changes.result != 'success' }}
     - run: echo 'docker-build failed' && false
-      if: ${{ needs.docker-build.result != 'success' }}
+      if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.docker-build.result) }}
     - run: echo 'docker-build-native failed' && false
-      if: ${{ needs.docker-build-native.result != 'success' }}
+      if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.docker-build-native.result) }}
 
 
   update-tested:

--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -206,7 +206,10 @@ jobs:
           # source errors against a prover several majors older than the one it
           # is named after -- which is exactly what the 9.2 row did until
           # OPAM_UPDATE_CMD was added above.  Assert the version instead.
-          PROVER_VERSION="$( { rocq --version || rocqc --version || coqc --version ; } 2>&1 | head -n 1 )"
+          # Do NOT merge stderr into this capture: the action runs the script
+          # under `set -x`, so `2>&1` collects the xtrace line rather than the
+          # version string, and every row fails the case below.
+          PROVER_VERSION="$( { rocq --version || rocqc --version || coqc --version ; } | head -n 1 )"
           echo "prover after dependency installation: $PROVER_VERSION"
           case "$PROVER_VERSION" in
             *"version ${{ matrix.env.EXPECT_VERSION }}"*) ;;

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,15 @@ on:
       - .github/workflows/python.yml
     branches:
       - main
+  # Safe to filter here only because no job in this workflow is a required
+  # status check: a workflow that never starts never reports one, so if
+  # `3.11` is ever made required this filter has to be replaced by the same
+  # always-runs-then-gates pattern that coq.yml uses.
   pull_request:
+    paths:
+      - training/**
+      - Makefile
+      - .github/workflows/python.yml
   workflow_dispatch:
 
 defaults:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,13 @@ KNOWNFILES   := Makefile _CoqProject
 
 .DEFAULT_GOAL := invoke-coqmakefile
 
+# Rocq >= 9.2 ships no `coq_makefile` binary (and no `coqc`/`rocqc`); the
+# generator is the `rocq makefile` subcommand.  Prefer coq_makefile wherever it
+# exists so Coq 8.x and Rocq 9.0/9.1 keep working exactly as before.
+COQ_MAKEFILE ?= $(shell command -v $(COQBIN)coq_makefile > /dev/null 2>&1 && echo '$(COQBIN)coq_makefile' || echo '$(COQBIN)rocq makefile')
+
 Makefile.coq: Makefile _CoqProject
-	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+	$(COQ_MAKEFILE) -f _CoqProject -o Makefile.coq
 
 SRC_DIR := theories
 MOD_NAME := NeuralNetInterp

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -25,3 +25,46 @@ EXTRA_COQ_CI_TARGETS := \
 
 .PHONY: coq-ci-target
 coq-ci-target: models theorem-statements $(EXTRA_COQ_CI_TARGETS)
+
+####################################################################
+##  Targets for CI rows that build "everything that can be built" ##
+####################################################################
+# Each exclusion below carries the measured reason it is excluded.  A `#` inside
+# a backslash-continued assignment comments out the rest of the *logical* line,
+# so these have to be one `+=` per entry rather than one continued list.
+
+# Files excluded from `ci-all` on every CI row.
+CI_SKIP :=
+
+# Never terminates.  Measured on mathcomp/mathcomp:2.4.0-rocq-prover-dev: still
+# the only live rocqworker after 60+ minutes at ~1 GB RSS, with no other file
+# left to compile.  Same symptom that took it out of EXTRA_COQ_CI_TARGETS above.
+CI_SKIP += theories/Util/Wf_Uint63/Proofs.v
+# Depends on Wf_Uint63/Proofs.vo (and on mathcomp's Rstruct).
+CI_SKIP += theories/Util/Wf_Uint63/Mathcomp.v
+# Depend on Wf_Uint63/Proofs.vo.
+CI_SKIP += theories/MaxOfTwoNumbersSimpler/Theorems/Attempt_01b_logit_delta.v
+CI_SKIP += theories/MaxOfTwoNumbersSimpler/Theorems/Attempt_02_SplitAttention.v
+CI_SKIP += theories/MaxOfTwoNumbersUndertrainedSimpler/Theorems/Attempt_02_SplitAttention.v
+# Need coq-vcfloat + LAProof, and no surviving CI row installs either.
+# coq-vcfloat was only ever on the 8.17/8.19/8.20 rows, and LAProof is not in
+# opam at all -- it was a from-source clone on the 8.17 row alone.
+CI_SKIP += theories/MaxOfTwoNumbersSimpler/Model/Rify.v
+CI_SKIP += theories/MaxOfTwoNumbersUndertrainedSimpler/Model/Rify.v
+
+.PHONY: ci-all
+ci-all: $(filter-out $(CI_SKIP:.v=.$(VO)),$(VFILES:.v=.$(VO)))
+
+# Same, minus the one file that needs coq-interval.  Used by the 8.20, 9.2, 9.3
+# and master rows, none of which installs the interval/coquelicot/analysis
+# stack.  On 9.2 and 9.3 that is not a choice: `opam install coq-interval
+# coq-coquelicot coq-mathcomp-analysis coq-mathcomp-reals-stdlib` is
+# `[ERROR] Package conflict!  ... not available because the package is pinned
+# to version 9.2.0 / 9.3+rc1` in both images.  On master it does resolve, but
+# only by building mathcomp dev, elpi and menhir dev from source, which is a
+# lot of runner time to gain exactly this one file.
+CI_SKIP_NO_INTERVAL := $(CI_SKIP)
+CI_SKIP_NO_INTERVAL += theories/MaxOfTwoNumbers/Theorems/Attempt_02_SplitAttention.v
+
+.PHONY: ci-all-no-interval
+ci-all-no-interval: $(filter-out $(CI_SKIP_NO_INTERVAL:.v=.$(VO)),$(VFILES:.v=.$(VO)))

--- a/theories/Torch/Slicing.v
+++ b/theories/Torch/Slicing.v
@@ -1,4 +1,6 @@
-From Coq Require Import Sint63 Uint63 PrimArray.
+(* [PArray] rather than [PrimArray]: the latter is not a valid [Coq.]-prefixed
+   logical path before Rocq 9, and every other file here imports [PArray]. *)
+From Coq Require Import Sint63 Uint63 PArray.
 From NeuralNetInterp.Torch Require Import Tensor.
 From NeuralNetInterp.Util Require Import Slice Arith.Classes Arith.Instances PolymorphicOption Nat Notations.
 Import Instances.Uint63.


### PR DESCRIPTION
The `CI (Coq)` workflow has no green run on record: 39 concluded runs going back
to 2025-07-01, 38 of them failed and one cancelled. Of the five `docker-build`
rows, only `master` — which builds `computed`, 102 of the 160 files in
`_CoqProject` — has been passing, and only in all-but-one of those runs. `8.20`
failed on every one of the last nineteen runs; `9.0` and `8.19` failed on every
one of those that reported a conclusion for them; `8.17` has failed on every run
since 2025-11-05.

This rebuilds the Rocq workflow around what is actually buildable today. Every
version bound, exclusion and dropped row below was measured in the image the
corresponding CI row uses, not inferred; the measurements are quoted inline.

## What the matrix looks like now

| row | image | targets | files |
| --- | --- | --- | --- |
| `master` | `rocq/rocq-prover:dev` | `computed` | 102 |
| `master (everything buildable)` | `rocq/rocq-prover:dev` | `ci-all-no-interval` | 152 |
| `9.3` | `rocq/rocq-prover:9.3` | `ci-all-no-interval` | 152 |
| `9.2` | `mathcomp/mathcomp:2.6.0-rocq-prover-9.2` | `ci-all-no-interval` | 152 |
| `9.1` | `mathcomp/mathcomp:2.4.0-rocq-prover-9.1` | `ci-all` | 153 |
| `9.0` | `mathcomp/mathcomp:2.4.0-rocq-prover-9.0` | `ci-all` | 153 |
| `8.20` | `coqorg/coq:8.20` | `ci-all-no-interval` | 152 |

plus the three unchanged `dev-native` rows.

## The residual on the new "builds more" job is zero

The `master (everything buildable)` row was the one thing that could not be
guessed, so it was measured rather than estimated, and measured on the image the
row actually uses.

Every row in the table above was built cold in its own container off this
branch's tree: `docker run <image> bash build.sh` with the row's own
`OPAM_DEPS`/`TGTS`, `make -k -j6 TIMED=1 <TGTS>`, and then a denominator taken
by `comm` against the `.v` list in `_CoqProject` rather than by counting `.vo`
files. On `rocq/rocq-prover:dev` the result is `make` exit 0, 152 `.vo` for a
160-file `_CoqProject`, `comm -13` (built but not declared) empty, `comm -23`
(declared but not built) exactly the eight files `CI_SKIP_NO_INTERVAL` names,
and zero occurrences of `Nothing to be done` in the make log.

So the expanded row needs no `continue-on-error:` and no exclusions beyond the
eight already justified in `Makefile.coq.local`: it is green as written. The
same instrument gives 153 of 160 on 9.0 and 9.1 (`ci-all`, the seven
`CI_SKIP` files missing) and 152 of 160 on 9.2, 9.3 and 8.20.

On runner time: nothing here is near the job limit. In run 19051159010
(2025-11-03, `main`) the `master`/`computed` row took 20m26s and the 8.17 row —
which built the *whole* 160-file default target at `-j2` after installing the
VST/interval stack and cloning and building LAProof — took 48m36s. Those were
two of that run's green rows; the run itself failed, on 9.0, 8.19 and 8.20.
Every new row builds fewer files than that with two dependencies instead of ten.

## The `master` row was not testing master

`mathcomp/mathcomp:2.4.0-rocq-prover-dev`, the image the `master` row used,
answers `rocq --version` with **"The Rocq Prover, version 9.2+alpha"** — older
than the released 9.2. Docker Hub publishes only two mathcomp dev tags
(`latest-rocq-prover-dev` and `2.4.0-rocq-prover-dev`) and both are stale.
`rocq/rocq-prover:dev` reports 9.3+alpha, so both `master` rows now use that.
Nothing in their target set needs mathcomp, so no image capability is lost.

## The 9.2 row silently downgraded the prover to Coq 8.16.1

This one is worth reading even if you skip the rest.

CI leaves `OPAM_UPDATE_CMD` empty on every row, so each row resolves against the
opam-repository snapshot frozen into its image. In the 9.2 image that snapshot's
newest `coq-flocq` is 4.2.2, which is bounded `coq < 8.21~`, and there is no
`rocq-flocq` at all. So `opam install -y coq-record-update coq-flocq` does not
fail — it **succeeds, at exit code 0**, by removing 16 packages
(`rocq-core 9.2.0`, `rocq-runtime 9.2.0`, `rocq-stdlib 9.1.0`, the whole mathcomp
2.6.0 stack, `rocq-elpi`, `rocq-hierarchy-builder`, `coqide-server`,
`rocq-bignums`, `rocq-micromega-plugin`, …) and installing `coq 8.16.1` in their
place. The row then reports source errors — `Unbound value String.compare`,
`Unknown scope delimiting key _type`, a left-recursive notation without an
explicit level — that are all pre-8.19 symptoms and have nothing to do with 9.2.
80 of 160 files built.

Two fixes, both in this PR:

* `OPAM_UPDATE_CMD: opam update -y` on the 9.2 row (and only there). Against the
  live repository, `coq-flocq 4.2.2` resolves through `coq-core 9.2.0` instead,
  and the plan is four installs and **zero removals**.
* An assertion after `opam install` on every row that the prover still reports
  the version the row is named after. An `opam install` that exits 0 is not
  evidence that the prover survived it.

Measured alternatives to `opam update`, for the record: `rocq-record-update
rocq-flocq` is exit 5 (no such packages), and `coq-record-update coq-flocq
rocq-core` is exit 20, `[ERROR] Package conflict! … not available because the
package is pinned to version 9.2.0`.

## 8.20 was saved; 8.19, 8.18 and 8.17 are dropped

### Why they broke

Not rot. Three deliberate forward-ports, each of which traded an old prover for
a current one:

* `5b496f9` "Adapt to rocq-prover/rocq#21211" (2025-11-05) dropped `at level 2`
  from 15 notations in `theories/Torch/Slicing.v` — 8.20 and later infer the
  level, 8.19 and earlier require it — and in the same commit added `PrimArray`
  to that file's `From Coq Require Import` line, a logical path that does not
  exist before Rocq 9. 8.17 was green on the `main` run immediately before this
  commit (run 19051159010, `06a316c`) and has failed on every run since,
  beginning with the run of the commit itself (19110435928).
* `6f2c7db` "Adapt to rocq-prover/rocq#21849" (2026-04-03) rewrote `%type` to
  `%_type` at 32 sites across four files. `%_type` does not parse before 8.19.
* `c1f7905` and `58058f2` (2026-07/08) dropped the explicit levels from the
  `_ @@1` / `_ @@2` relation-pair notations so they inherit the stdlib's, which
  Rocq 9.4 moved from 30 to 1.

Each was the right call for the prover being adapted to. What follows takes one
of them back where it costs nothing — the `PrimArray` import — and stops
pretending about the rest.

**8.20 is back and green.** Its failure was never source-side: it installed
`coq-interval coq-vcfloat coq-vst coq-vst-lib …` and died in that install,
before compiling a single `.v` file — `coq-vst.3.1beta` pulls `coq-compcert` and
then rejects it, `COMPCERT VERSION MISMATCH: COMPCERT_VERSION=version=3.15 but
…/compcert/VERSION=version=3.17`. The repair taken here is not to install VST at
all: nothing in `ci-all-no-interval` uses it. With the same minimal
`coq-record-update coq-flocq` pair the 9.x rows use, 8.20 installs clean and
builds 152 of 160.

The other three stay dropped, each with its cause measured in the *same*
configuration that rescued 8.20 — plain `coqorg/coq:<v>` image, minimal
dependency pair — so these are source limits, not solver accidents. Each
deletion is left in the workflow as a comment naming its cause.

* **8.19** — `theories/Torch/Slicing.v:222`, `A left-recursive notation must
  have an explicit level.` 106 of 160 files built. This one *can* be fixed, and
  the fix was written and measured: putting back the `at level 2` / `at level 1`
  that `5b496f9` removed from the 15 slicing notations takes 8.19 to 152 of 160
  at exit 0. It was then reverted,
  because it is not backwards compatible. `_ .[ _ , .. , _ ]` has to sit at the
  same level as the stdlib `_ .[ _ ]` whose prefix it shares, and that notation
  moved: it is **at level 2 in 8.19, 8.20, 9.0 and 9.1, and at level 1 in 9.2,
  9.3 and master** (read off each build's own `notation-incompatible-prefix`
  warnings). 8.20 and later infer the right one; a literal cannot be right on
  both sides. With `at level 2` written down, 9.2, 9.3 and master turn red at
  `theories/TransformerLens/HookedTransformer.v:115`, `Syntax error: '<-' or ']'
  expected after [term level 200]`. Trading three current provers for one
  three-year-old one is not a trade worth making, so 8.19 goes.
* **8.18** — `theories/TransformerLens/HookedTransformer.v:128`, `Missing
  notation term for variables i1 i_ j1 j_ k1 k_, probably an ill-typed
  expression`. 83 of 160 built. It also hits 8.17's `%_type` problem.
* **8.17** — `theories/Util/PolymorphicSigma.v:24` uses the `%_type` scope
  delimiter, which does not exist before 8.19 (there it is `%type`). No form
  parses on both sides of that boundary, so supporting 8.17 means reverting
  `6f2c7db` at all 32 sites and carrying a second spelling for a prover four
  majors behind. This is the row that was green until 2025-11-05; it is dropped
  because keeping it means undoing two upstream adaptations, not because it
  never worked.

## Source changes: one line

`theories/Torch/Slicing.v` imported `PrimArray`; every other file in the tree
imports `PArray`, and `Coq.PrimArray` only became a valid logical path in Rocq
9. Reverting that half of `5b496f9` is the whole of the source change here:
on 8.20 it is the only thing standing between `Slicing.v` and a green row, and
on 8.19 it is the first of the two things (the notation levels are the other).
Changing it back to `PArray` takes 8.20 from 106 of 160 to a green 152, and is
a no-op on 9.0 through master, all of which stayed at their previous counts
across the change.

The 15 explicit notation levels described under 8.19 above were written,
measured, and **reverted**; they are not in this PR.

### `Rstruct`: verified, and correctly spelled already

The one other candidate was the three `From mathcomp.reals_stdlib Require Import
Rstruct.` lines. Verified rather than assumed, by compiling all three spellings
in each image:

* On `mathcomp/mathcomp:2.4.0-rocq-prover-9.0` and `…-9.1`: bare `From mathcomp
  Require Import Rstruct.` and `From mathcomp.reals_stdlib Require Import
  Rstruct.` both compile (exit 0); `From mathcomp.analysis Require Import
  Rstruct.` does not (exit 1). The only `Rstruct.vo` on disk is
  `…/mathcomp/reals_stdlib/Rstruct.vo`.
* On the 8.20, 9.2, 9.3 and dev images all three fail, because those rows do not
  install mathcomp at all — which is why every file that imports `Rstruct` is
  outside their target set.

HEAD already uses the spelling that works. No change.

## New `make` targets

`ci-all` and `ci-all-no-interval` in `Makefile.coq.local` build everything in
`_CoqProject` except an explicit exclusion list, each entry carrying the measured
reason it is excluded. A `#` inside a backslash-continued assignment comments out
the rest of the logical line, so the list is one `+=` per entry rather than one
continued list.

* `theories/Util/Wf_Uint63/Proofs.v` — does not terminate. Left running on the
  dev image it was still the only live `rocqworker` after 60+ minutes at ~1 GB
  RSS with nothing else left to compile. This is the same file the pre-existing
  `EXTRA_COQ_CI_TARGETS` comment already calls out as looping on master.
* `theories/Util/Wf_Uint63/Mathcomp.v`,
  `theories/MaxOfTwoNumbersSimpler/Theorems/Attempt_01b_logit_delta.v`,
  `theories/MaxOfTwoNumbersSimpler/Theorems/Attempt_02_SplitAttention.v`,
  `theories/MaxOfTwoNumbersUndertrainedSimpler/Theorems/Attempt_02_SplitAttention.v`
  — depend on `Proofs.vo` (read off `.Makefile.coq.d`).
* `theories/MaxOfTwoNumbersSimpler/Model/Rify.v`,
  `theories/MaxOfTwoNumbersUndertrainedSimpler/Model/Rify.v` — need `coq-vcfloat`
  and LAProof, and no surviving row installs either. `coq-vcfloat` was only ever
  on the 8.17/8.19/8.20 rows' `OPAM_DEPS`, and it is what 8.20 had to give up to
  come back (see above). LAProof is not in opam at all — it was a from-source
  clone on the 8.17 row alone, and 8.17 is dropped.
* `ci-all-no-interval` drops one more,
  `theories/MaxOfTwoNumbers/Theorems/Attempt_02_SplitAttention.v`, which needs
  `coq-interval`. It is what the 8.20, 9.2, 9.3 and master rows build. On 9.2
  and 9.3 that is not a choice: `opam install coq-interval coq-coquelicot
  coq-mathcomp-analysis coq-mathcomp-reals-stdlib` is `[ERROR] Package
  conflict!` in both images, before and after `opam update`. On dev it does
  resolve, but only by building mathcomp dev, elpi and menhir dev from source,
  which is a lot of runner time for one file. On 8.20 the interval stack is what
  was breaking the row in the first place (see above), so it stays out.

## Rocq CI is skipped on Python-only changes

`check-all` is a required status check, and a workflow that never starts never
reports one — a `paths:` filter on `pull_request:` would leave every Python-only
PR sitting on "Expected — waiting for status to be reported" forever. So the
workflow still always starts, and a new `changes` job decides:

* it diffs against the PR base (or `github.event.before` on a push) and sets
  `coq=true` if anything under `theories/`, `etc/`, `_CoqProject`, `Makefile`,
  `Makefile.coq.local` or `.github/workflows/coq.yml` changed;
* it **fails open** — an unusable base sha, an unresolvable base, or a failed
  `git diff` all build everything rather than skip;
* the build jobs gate on it, and `check-all` counts `skipped` as passing, so a
  Python-only PR gets a green `check-all` in about a minute.

`python.yml` gets the mirror-image `paths:` filter on `pull_request:`. That is
only safe because no job in that workflow is a required status check; the
comment there says so, and says what to do if one ever is.

## Relation to the open CI PRs

Four open PRs touch this workflow. Deliberately not `#`-linked, to avoid
spraying cross-references; they are PR 3 (`test-8.18`), PR 76 (`adjust-ci`),
PR 91 (`fix-ci-8-20`) and PR 92 (`fix-ci-8-19-8-20`).

91 and 92 add `OPAM_UPDATE_CMD: opam update -y` to the 8.20 (and 8.19) rows.
That hypothesis is **not** falsified here, and it is worth recording what it
does: with the repository refreshed, the old 8.20 dependency list resolves to
`coq-vst 2.15` rather than `coq-vst 3.1beta`, i.e. away from the version that
rejects its own `coq-compcert` — so those PRs may well have fixed the install.
They were not built out, because the alternative measured here is strictly
cheaper: dropping VST/interval from a row whose target set never uses them turns
8.20 green in eleven minutes and does not build CompCert on every CI run. The
`opam update -y` idea survives in this PR on the row where it is load-bearing
and no substitute exists, 9.2.

76 comments out 8.18 with the same `HookedTransformer.v:128` error reproduced
here, and moves rows to `computed`; this PR keeps the 8.18 verdict, quotes the
same error, and goes the other way on targets. 76 also carries three debug lines
(`Set Printing Depth`, `Set Printing Coercions`, `Show.`) in
`theories/Util/Wf_Uint63/Proofs.v` that presumably should not land. 3 adds an
8.18 row, which this PR's measurement says cannot pass. All four are supersedable
by this one, but nothing here depends on that.

## Also

The root `Makefile` now picks `rocq makefile` when `coq_makefile` is absent.
Rocq 9.2 and later ship no `coq_makefile` binary (and no `coqc`/`rocqc`); the
generator is a `rocq` subcommand. `coq_makefile` is still preferred wherever it
exists, so Coq 8.x and Rocq 9.0/9.1 are unaffected.
