### PR TITLE
DO NOT MERGE: probe that a Python-only change skips the Rocq build jobs

### DIFF
--- a/training/ci_skip_probe.txt
+++ b/training/ci_skip_probe.txt
@@ -1,0 +1,1 @@
+# probe: verifies that a Python-only change skips the Rocq build jobs


### PR DESCRIPTION
Throwaway. Opened against `claude/fix-rocq-ci` (not `main`) so the diff is a single Python-only file and the workflow under test is the new one. Expected: `Detect Rocq-relevant changes` reports `coq=false`, every `docker-build`/`docker-build-native` job is skipped, and `check-all` is green. Will be closed as soon as that is observed.